### PR TITLE
Add group photo gallery page

### DIFF
--- a/_data/gallery.yml
+++ b/_data/gallery.yml
@@ -1,6 +1,7 @@
-- id: group
-  name: Group
+- id: group-photo
+  title: "Group Photo"
+  date: 2026-03
   photos:
-    - full: /assets/img/gallery/group/placeholder.jpg
-      thumb: /assets/img/gallery/group/placeholder.jpg
-      caption: "Group photo — coming soon!"
+    - full: /assets/img/gallery/group/placeholder.svg
+      thumb: /assets/img/gallery/group/placeholder.svg
+      caption: "Group photo — coming soon! Add yours via PR."

--- a/_data/gallery.yml
+++ b/_data/gallery.yml
@@ -1,0 +1,6 @@
+- id: group
+  name: Group
+  photos:
+    - full: /assets/img/gallery/group/placeholder.jpg
+      thumb: /assets/img/gallery/group/placeholder.jpg
+      caption: "Group photo — coming soon!"

--- a/_pages/gallery.md
+++ b/_pages/gallery.md
@@ -2,7 +2,7 @@
 layout: page
 title: Gallery
 permalink: /gallery/
-description: Photos of the group
+description: Group photos and activity snapshots
 nav: true
 nav_order: 8
 images:
@@ -10,31 +10,19 @@ images:
   photoswipe: true
 ---
 
-Group photos and activity snapshots.
+Group activity photos and memorable moments.
 
-To add your photos, please submit a pull request following the [instructions](#how-to-add-photos) at the bottom of this page.
-
----
-
-## Group Photos
-
-<div class="row">
-    <div class="col-sm mt-3 mt-md-0">
-        {% include figure.liquid loading="eager" path="assets/img/gallery/group/placeholder.jpg" title="Group photo" class="img-fluid rounded z-depth-1" %}
-    </div>
-</div>
+To add photos from an event, please submit a pull request following the [instructions](#how-to-add-photos) at the bottom.
 
 ---
 
-## Members
-
-{% for member in site.data.gallery %}
-### {{ member.name }}
+{% for event in site.data.gallery %}
+### {{ event.title }}
 
 <div class="row">
-    {% for photo in member.photos %}
+    {% for photo in event.photos %}
     <div class="col-sm-6 col-md-4 mt-3 mt-md-0">
-        <a href="{{ photo.full }}" data-lightbox="{{ member.id }}" data-title="{{ photo.caption }}">
+        <a href="{{ photo.full }}" data-lightbox="{{ event.id }}" data-title="{{ photo.caption }}">
             <img src="{{ photo.thumb }}" alt="{{ photo.caption }}" class="img-fluid rounded z-depth-1" loading="lazy">
         </a>
     </div>
@@ -47,19 +35,19 @@ To add your photos, please submit a pull request following the [instructions](#h
 ## How to Add Photos
 
 1. **Fork** this repository
-2. Create a folder under `assets/img/gallery/your-name/`
-3. Add your photos (`.jpg`, `.png`, or `.webp`)
-4. **Update** `_data/gallery.yml` with your entries:
+2. Place photos under `assets/img/gallery/event-name/`
+3. **Update** `_data/gallery.yml` with a new event entry:
 
 ```yaml
-- id: your-name
-  name: Your Name
+- id: event-name
+  title: "Event Title"
+  date: YYYY-MM-DD
   photos:
-    - full: /assets/img/gallery/your-name/photo1.jpg
-      thumb: /assets/img/gallery/your-name/photo1.jpg
+    - full: /assets/img/gallery/event-name/photo1.jpg
+      thumb: /assets/img/gallery/event-name/photo1.jpg
       caption: "A short description"
 ```
 
-5. Submit a **Pull Request** back to the main repository
+4. Submit a **Pull Request**
 
-> 💡 Tip: For best performance, resize your photos to ~1200px wide before adding.
+> 💡 Tip: Resize photos to ~1200px wide before adding for best performance.

--- a/_pages/gallery.md
+++ b/_pages/gallery.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: Gallery
+permalink: /gallery/
+description: Photos of the group
+nav: true
+nav_order: 8
+images:
+  lightbox2: true
+  photoswipe: true
+---
+
+Group photos and activity snapshots.
+
+To add your photos, please submit a pull request following the [instructions](#how-to-add-photos) at the bottom of this page.
+
+---
+
+## Group Photos
+
+<div class="row">
+    <div class="col-sm mt-3 mt-md-0">
+        {% include figure.liquid loading="eager" path="assets/img/gallery/group/placeholder.jpg" title="Group photo" class="img-fluid rounded z-depth-1" %}
+    </div>
+</div>
+
+---
+
+## Members
+
+{% for member in site.data.gallery %}
+### {{ member.name }}
+
+<div class="row">
+    {% for photo in member.photos %}
+    <div class="col-sm-6 col-md-4 mt-3 mt-md-0">
+        <a href="{{ photo.full }}" data-lightbox="{{ member.id }}" data-title="{{ photo.caption }}">
+            <img src="{{ photo.thumb }}" alt="{{ photo.caption }}" class="img-fluid rounded z-depth-1" loading="lazy">
+        </a>
+    </div>
+    {% endfor %}
+</div>
+{% endfor %}
+
+---
+
+## How to Add Photos
+
+1. **Fork** this repository
+2. Create a folder under `assets/img/gallery/your-name/`
+3. Add your photos (`.jpg`, `.png`, or `.webp`)
+4. **Update** `_data/gallery.yml` with your entries:
+
+```yaml
+- id: your-name
+  name: Your Name
+  photos:
+    - full: /assets/img/gallery/your-name/photo1.jpg
+      thumb: /assets/img/gallery/your-name/photo1.jpg
+      caption: "A short description"
+```
+
+5. Submit a **Pull Request** back to the main repository
+
+> 💡 Tip: For best performance, resize your photos to ~1200px wide before adding.

--- a/assets/img/gallery/README.md
+++ b/assets/img/gallery/README.md
@@ -1,0 +1,16 @@
+# Group Photo Gallery
+
+Add your photos here by submitting a Pull Request!
+
+## Directory structure
+
+```
+assets/img/gallery/
+├── your-name/
+│   ├── photo1.jpg
+│   └── photo2.jpg
+└── group/
+    └── ...
+```
+
+Then update `_data/gallery.yml` to include your entries.

--- a/assets/img/gallery/group/placeholder.svg
+++ b/assets/img/gallery/group/placeholder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <rect width="800" height="400" fill="#f0f0f0"/>
+  <text x="400" y="190" font-family="Arial, sans-serif" font-size="24" fill="#999" text-anchor="middle">📸 Group Photo</text>
+  <text x="400" y="230" font-family="Arial, sans-serif" font-size="16" fill="#bbb" text-anchor="middle">Add your photo via PR!</text>
+</svg>


### PR DESCRIPTION
New gallery page for group photos using Lightbox2 + data-driven layout.

Members can submit photos via PR to `assets/img/gallery/` and `_data/gallery.yml`.